### PR TITLE
feat drop wagtail transfer

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -112,7 +112,6 @@ WAGTAIL_APPS = [
     "modelcluster",
     "taggit",
     "wagtailmetadata",
-    "wagtail_transfer",
 ]
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
@@ -364,18 +363,3 @@ WAGTAILEMBEDS_RESPONSIVE_HTML = True
 # ------------------------------------------------------------------------------
 WAGTAIL_SITE_NAME = "African Cities Lab"
 WAGTAILADMIN_BASE_URL = "https://africancitieslab.org"
-
-# Wagtail transfer
-# ------------------------------------------------------------------------------
-# WAGTAILTRANSFER_SOURCES = {
-#     "staging": {
-#         "BASE_URL": "staging.africancitieslab.org",
-#         "SECRET_KEY": env("WAGTAILTRANSFER_STAGING_SECRET_KEY"),
-#     },
-#     "production": {
-#         "BASE_URL": "africancitieslab.org",
-#         "SECRET_KEY": env("WAGTAILTRANSFER_PRODUCTION_SECRET_KEY"),
-#     },
-# }
-
-WAGTAILTRANSFER_SECRET_KEY = env("WAGTAILTRANSFER_SECRET_KEY", default="some-key")

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,7 +8,6 @@ from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.documents import urls as wagtaildocs_urls
-from wagtail_transfer import urls as wagtailtransfer_urls
 
 urlpatterns = [
     # Language Redirect
@@ -42,8 +41,6 @@ urlpatterns = [
     # Alternatively, if you want Wagtail pages to be served from a subpath of your site,
     # rather than the site root:
     #    url(r"^pages/", include(wagtail_urls)),
-    # wagtail transfer
-    path("wagtail-transfer/", include(wagtailtransfer_urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 urlpatterns = urlpatterns + i18n_patterns(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,4 +24,3 @@ wagtail==5.2.3  # https://github.com/wagtail/wagtail
 wagtail-localize==1.8  # https://github.com/wagtail/wagtail-localize
 wagtailmenus==3.1.9  # https://wagtailmenus.readthedocs.io/en/stable
 wagtail-metadata==4.0.2  # https://github.com/neon-jungle/wagtail-metadata
-wagtail-transfer==0.9.3  # https://github.com/wagtail/wagtail-transfer


### PR DESCRIPTION
- fix: default wagtail transfer key if no env var
- Feat homepage & about page make it entire dynamic
- fix: wagtail transfer url path
- feat: drop wagtail transfer
